### PR TITLE
Use latest version of GCC-Bridge and fix unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,9 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <gcc.bridge.version>0.9.2594</gcc.bridge.version>
+        <gcc.bridge.version>0.9.2600</gcc.bridge.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
 

--- a/src/main/c/triangle.c
+++ b/src/main/c/triangle.c
@@ -312,7 +312,7 @@
 /*   compiler is smarter, feel free to replace the "int" with "void".        */
 /*   Not that it matters.                                                    */
 
-#define VOID int
+#define VOID void
 
 /* Two constants for algorithms based on random sampling.  Both constants    */
 /*   have been chosen empirically to optimize their respective algorithms.   */

--- a/src/test/java/org/orbisgis/jtriangle/JTriangleTest.java
+++ b/src/test/java/org/orbisgis/jtriangle/JTriangleTest.java
@@ -27,7 +27,7 @@ public class JTriangleTest {
     };
 
     Ptr in = triangle.createInputStruct(new DoublePtr(pointlist), new DoublePtr(pointAttribute),
-            new DoublePtr(pointMarker),pointlist.length,numberofpointattributes,new IntPtr(),new DoublePtr(),
+            new DoublePtr(pointMarker),pointlist.length/2,numberofpointattributes,new IntPtr(),new DoublePtr(),
             new DoublePtr(),0, 0,0,new IntPtr(0),new IntPtr(),0,new DoublePtr(),0,new DoublePtr(regions), regions.length);
 
 

--- a/src/test/java/org/orbisgis/jtriangle/JTriangleTest.java
+++ b/src/test/java/org/orbisgis/jtriangle/JTriangleTest.java
@@ -28,7 +28,7 @@ public class JTriangleTest {
 
     Ptr in = triangle.createInputStruct(new DoublePtr(pointlist), new DoublePtr(pointAttribute),
             new DoublePtr(pointMarker),pointlist.length/2,numberofpointattributes,new IntPtr(),new DoublePtr(),
-            new DoublePtr(),0, 0,0,new IntPtr(0),new IntPtr(),0,new DoublePtr(),0,new DoublePtr(regions), regions.length);
+            new DoublePtr(),0, 0,0,new IntPtr(0),new IntPtr(),0,new DoublePtr(),0,new DoublePtr(regions), regions.length/4);
 
 
     // Run triangulation


### PR DESCRIPTION
This bumps up the pom file to use the latest build of GCC-Bridge which contains some workarounds to support the use of highly platform-specific pointer mainipulation.

I've also fixed two of the input parameters.

Your unit test now runs without error. Perhaps you can add some assertions to check the output?
